### PR TITLE
Rename onBeforeResolved to onMessage. Remove onBeforeFinalized.

### DIFF
--- a/.changeset/mean-beans-give.md
+++ b/.changeset/mean-beans-give.md
@@ -1,0 +1,5 @@
+---
+"generative.js": patch
+---
+
+Rename onBeforeResolved to onMessage. Remove onBeforeFinalized.

--- a/packages/generative.js/src/components/Assistant.tsx
+++ b/packages/generative.js/src/components/Assistant.tsx
@@ -22,8 +22,7 @@ export function Assistant({
   requestOptions = {},
   clientOptions = {},
   children,
-  onBeforeResolved,
-  onBeforeFinalized,
+  onMessage,
 }: {
   content?: string; // set content to use Assistant as literal, no completion will be requested
   className?: string;
@@ -33,8 +32,7 @@ export function Assistant({
   requestOptions?: Partial<ChatCompletionCreateParamsStreaming>;
   clientOptions?: ClientOptions;
   children?: ReactNode | MessageRenderFunc<AssistantMessage>;
-  onBeforeResolved?: (message: AssistantMessage) => void;
-  onBeforeFinalized?: (message: AssistantMessage) => void;
+  onMessage?: (message: AssistantMessage) => void;
 }) {
   const action = useCallback<ActionType>(
     async ({ messages, signal }) =>
@@ -54,8 +52,7 @@ export function Assistant({
       className={className}
       type={content ? { role: "assistant", content } : action}
       typeName="Assistant"
-      onBeforeResolved={onBeforeResolved}
-      onBeforeFinalized={onBeforeFinalized}
+      onMessage={onMessage}
     >
       {children}
     </Message>

--- a/packages/generative.js/src/components/Message.tsx
+++ b/packages/generative.js/src/components/Message.tsx
@@ -13,23 +13,20 @@ export function Message<MessageType extends GenerativeMessage>({
   className,
   children,
   deps = [],
-  onBeforeResolved,
-  onBeforeFinalized,
+  onMessage,
 }: {
   className?: string;
   type: GenerativeElement["type"];
   typeName?: string;
   children?: ReactNode | MessageRenderFunc<MessageType>;
   deps?: DependencyList;
-  onBeforeResolved?: (message: MessageType) => void;
-  onBeforeFinalized?: (message: MessageType) => void;
+  onMessage?: (message: MessageType) => void;
 }) {
   const { id, ref, message, ready, complete } = useGenerative<MessageType>({
     type,
     typeName,
     deps,
-    onBeforeResolved,
-    onBeforeFinalized,
+    onMessage,
   });
 
   // const renderCount = useRef(0);

--- a/packages/generative.js/src/components/Router.tsx
+++ b/packages/generative.js/src/components/Router.tsx
@@ -153,7 +153,7 @@ export function Decision({
         <Assistant
           toolChoice={selectPathTool}
           tools={tools}
-          onBeforeResolved={onBeforeResolved}
+          onMessage={onBeforeResolved}
         ></Assistant>
       </>
     );

--- a/packages/generative.js/src/components/System.tsx
+++ b/packages/generative.js/src/components/System.tsx
@@ -6,14 +6,12 @@ export function System({
   content,
   children,
   className,
-  onBeforeResolved,
-  onBeforeFinalized,
+  onMessage,
 }: {
   content: string;
   children?: ReactNode | ((message: SystemMessage) => ReactNode);
   className?: string;
-  onBeforeResolved?: (message: SystemMessage) => void;
-  onBeforeFinalized?: (message: SystemMessage) => void;
+  onMessage?: (message: SystemMessage) => void;
 }) {
   const message = useMemo(
     (): SystemMessage => ({ role: "system", content }),
@@ -26,8 +24,7 @@ export function System({
       typeName="System"
       deps={deps}
       className={className}
-      onBeforeResolved={onBeforeResolved}
-      onBeforeFinalized={onBeforeFinalized}
+      onMessage={onMessage}
     >
       {children}
     </Message>

--- a/packages/generative.js/src/components/User.tsx
+++ b/packages/generative.js/src/components/User.tsx
@@ -6,14 +6,12 @@ export function User({
   content,
   children,
   className,
-  onBeforeResolved,
-  onBeforeFinalized,
+  onMessage,
 }: {
   content?: UserMessage["content"];
   children?: ReactNode | ((message: UserMessage) => ReactNode);
   className?: string;
-  onBeforeResolved?: (message: UserMessage) => void;
-  onBeforeFinalized?: (message: UserMessage) => void;
+  onMessage?: (message: UserMessage) => void;
 }) {
   const type = useMemo(
     () => (content ? { role: "user" as const, content } : "LISTENER"),
@@ -26,8 +24,7 @@ export function User({
       type={type}
       typeName="User"
       deps={deps}
-      onBeforeResolved={onBeforeResolved}
-      onBeforeFinalized={onBeforeFinalized}
+      onMessage={onMessage}
     >
       {children}
     </Message>

--- a/packages/generative.js/src/hooks/use-generative.ts
+++ b/packages/generative.js/src/hooks/use-generative.ts
@@ -46,8 +46,7 @@ export type useGenerativeProps<MessageType extends GenerativeMessage> = {
   type: GenerativeElement["type"];
   typeName?: string;
   deps?: DependencyList;
-  onBeforeResolved?: (message: MessageType) => void;
-  onBeforeFinalized?: (message: MessageType) => void;
+  onMessage?: (message: MessageType) => void;
 };
 
 export type useGenerativeReturnType<MessageType extends GenerativeMessage> = {
@@ -64,8 +63,7 @@ export function useGenerative<MessageType extends GenerativeMessage>({
   type,
   typeName = "anonymous",
   deps = [],
-  onBeforeResolved,
-  onBeforeFinalized,
+  onMessage,
 }: useGenerativeProps<MessageType>): useGenerativeReturnType<MessageType> {
   const logger = getLogger("useGenerative");
   const id = useId();
@@ -121,7 +119,7 @@ export function useGenerative<MessageType extends GenerativeMessage>({
         if (node.state.message) {
           setMessage(message);
         }
-        onBeforeResolved && onBeforeResolved(message);
+        onMessage && onMessage(message);
         setStatus(node.status);
       },
       onError: (error: unknown) => {
@@ -141,7 +139,6 @@ export function useGenerative<MessageType extends GenerativeMessage>({
   // finalized after render
   useLayoutEffect(() => {
     if (status === "RESOLVED") {
-      onBeforeFinalized && onBeforeFinalized(message as MessageType);
       generative.finalize(id);
       setStatus("FINALIZED");
     }

--- a/packages/generative.js/test/tool.test.tsx
+++ b/packages/generative.js/test/tool.test.tsx
@@ -29,7 +29,7 @@ test("should use tool", async () => {
     } else {
       return (
         <Assistant
-          onBeforeResolved={(message) => {
+          onMessage={(message) => {
             const call = getToolCall(tool, message);
             assert(call);
             setSum(call.data.sum);


### PR DESCRIPTION
Lifecycle events hard to understand. Don't require that fine grain control at this point in time.